### PR TITLE
Frames / Titan Incompatibilty

### DIFF
--- a/src/main/java/com/tinkerpop/frames/FramedElement.java
+++ b/src/main/java/com/tinkerpop/frames/FramedElement.java
@@ -74,11 +74,7 @@ public class FramedElement implements InvocationHandler {
         final Annotation[] annotations = method.getAnnotations();
         for (final Annotation annotation : annotations) {
             if (this.framedGraph.hasAnnotationHandler(annotation.annotationType())) {
-                if (this.element instanceof Vertex) {
-                    return this.framedGraph.getAnnotationHandler(annotation.annotationType()).processVertex(annotation, method, arguments, this.framedGraph, (Vertex) this.element);
-                } else if (this.element instanceof Edge) {
-                    return this.framedGraph.getAnnotationHandler(annotation.annotationType()).processEdge(annotation, method, arguments, this.framedGraph, (Edge) this.element, this.direction);
-                }
+                return this.framedGraph.getAnnotationHandler(annotation.annotationType()).processElement(annotation, method, arguments, this.framedGraph, this.element, this.direction);
             }
         }
 

--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -1,9 +1,6 @@
 package com.tinkerpop.frames.annotations;
 
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Graph;
-import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.*;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.ClassUtilities;
 import com.tinkerpop.frames.FramedElement;
@@ -21,6 +18,14 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
     }
 
     @Override
+    public Object processElement(final Adjacency annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+        if (element instanceof Vertex) {
+            return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     public Object processVertex(final Adjacency adjacency, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex vertex) {
         if (ClassUtilities.isGetMethod(method)) {
             final FramedVertexIterable r = new FramedVertexIterable(framedGraph, vertex.getVertices(adjacency.direction(), adjacency.label()), ClassUtilities.getGenericClass(method));
@@ -63,11 +68,6 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
         }
 
         return null;
-    }
-
-    @Override
-    public Object processEdge(final Adjacency annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge element, final Direction direction) {
-        throw new UnsupportedOperationException();
     }
 
     private void removeEdges(final Direction direction, final String label, final Vertex element, final Vertex otherVertex, final FramedGraph framedGraph) {

--- a/src/main/java/com/tinkerpop/frames/annotations/AnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AnnotationHandler.java
@@ -1,8 +1,7 @@
 package com.tinkerpop.frames.annotations;
 
 import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.frames.FramedGraph;
 
 import java.lang.annotation.Annotation;
@@ -11,7 +10,5 @@ import java.lang.reflect.Method;
 public interface AnnotationHandler<T extends Annotation> {
     public Class<T> getAnnotationType();
 
-    public Object processVertex(final T annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex element);
-
-    public Object processEdge(final T annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge element, final Direction direction);
+    public Object processElement(final T annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction);
 }

--- a/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
@@ -2,6 +2,7 @@ package com.tinkerpop.frames.annotations;
 
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Domain;
 import com.tinkerpop.frames.FramedGraph;
@@ -16,11 +17,14 @@ public class DomainAnnotationHandler implements AnnotationHandler<Domain> {
     }
 
     @Override
-    public Object processVertex(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex vertex) {
-        throw new UnsupportedOperationException();
+    public Object processElement(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+        if (element instanceof Edge) {
+            return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);
+        } else {
+            throw new UnsupportedOperationException();
+        }
     }
 
-    @Override
     public Object processEdge(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
         return framedGraph.frame(edge.getVertex(direction), method.getReturnType());
     }

--- a/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
@@ -2,6 +2,7 @@ package com.tinkerpop.frames.annotations;
 
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.ClassUtilities;
 import com.tinkerpop.frames.FramedEdgeIterable;
@@ -20,6 +21,14 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
     }
 
     @Override
+    public Object processElement(final Incidence annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+        if (element instanceof Vertex) {
+            return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     public Object processVertex(final Incidence incidence, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex element) {
         if (ClassUtilities.isGetMethod(method)) {
             return new FramedEdgeIterable(framedGraph, element.getEdges(incidence.direction(), incidence.label()), incidence.direction(), ClassUtilities.getGenericClass(method));
@@ -34,11 +43,6 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
         }
 
         return null;
-    }
-
-    @Override
-    public Object processEdge(final Incidence annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge element, final Direction direction) {
-        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
@@ -18,16 +18,7 @@ public class PropertyAnnotationHandler implements AnnotationHandler<Property> {
     }
 
     @Override
-    public Object processVertex(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex vertex) {
-        return process(annotation, method, arguments, vertex);
-    }
-
-    @Override
-    public Object processEdge(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
-        return process(annotation, method, arguments, edge);
-    }
-
-    private Object process(final Property annotation, final Method method, final Object[] arguments, final Element element) {
+    public Object processElement(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (ClassUtilities.isGetMethod(method)) {
             return element.getProperty(annotation.value());
         } else if (ClassUtilities.isSetMethod(method)) {

--- a/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
@@ -2,6 +2,7 @@ package com.tinkerpop.frames.annotations;
 
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.Range;
@@ -16,11 +17,14 @@ public class RangeAnnotationHandler implements AnnotationHandler<Range> {
     }
 
     @Override
-    public Object processVertex(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex vertex) {
-        throw new UnsupportedOperationException();
+    public Object processElement(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+        if (element instanceof Edge) {
+            return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);
+        } else {
+            throw new UnsupportedOperationException();
+        }
     }
 
-    @Override
     public Object processEdge(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
         return framedGraph.frame(edge.getVertex(direction.opposite()), method.getReturnType());
     }

--- a/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
@@ -25,6 +25,14 @@ public class GremlinGroovyAnnotationHandler implements AnnotationHandler<Gremlin
     }
 
     @Override
+    public Object processElement(final GremlinGroovy annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+        if (element instanceof Vertex) {
+            return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
+        } else {
+            throw new UnsupportedOperationException("This method only works for vertices");
+        }
+    }
+
     public Object processVertex(final GremlinGroovy annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex vertex) {
         if (ClassUtilities.isGetMethod(method)) {
             final Pipe pipe = Gremlin.compile(annotation.value());
@@ -35,8 +43,4 @@ public class GremlinGroovyAnnotationHandler implements AnnotationHandler<Gremlin
         }
     }
 
-    @Override
-    public Object processEdge(final GremlinGroovy annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
-        throw new UnsupportedOperationException("This method only works for vertices");
-    }
 }


### PR DESCRIPTION
This fixes an incompatibility between Frames and Titan as discussed here; https://groups.google.com/forum/?fromgroups=#!topic/aureliusgraphs/uhODETrCUL8

Essentially, Titan edges implement Vertex and cause the logic for handling annotations in FramedElement to fail.
