### PR TITLE
Allow the GremlinGroovy AnnotationHandler to deal with non-iterable return types.

### DIFF
--- a/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
@@ -37,7 +37,12 @@ public class GremlinGroovyAnnotationHandler implements AnnotationHandler<Gremlin
         if (ClassUtilities.isGetMethod(method)) {
             final Pipe pipe = Gremlin.compile(annotation.value());
             pipe.setStarts(new SingleIterator<Element>(vertex));
-            return new FramedVertexIterable(framedGraph, pipe, ClassUtilities.getGenericClass(method));
+            FramedVertexIterable r = new FramedVertexIterable(framedGraph, pipe, ClassUtilities.getGenericClass(method));
+            if (ClassUtilities.returnsIterable(method)) {
+                return r;
+            } else {
+                return r.iterator().hasNext() ? r.iterator().next() : null;
+            }
         } else {
             throw new UnsupportedOperationException("Gremlin only works with getters");
         }

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -282,4 +282,10 @@ public class FramedVertexTest extends TestCase {
         }
         assertEquals(counter, 2);
     }
+
+    public void testGetGremlinGroovySingleItem() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Person coCreator = marko.getRandomCoCreators();
+        assertTrue(coCreator.getName().equals("josh") || coCreator.getName().equals("peter"));
+    }
 }

--- a/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
+++ b/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
@@ -63,4 +63,7 @@ public interface Person extends NamedObject {
     @GremlinGroovy("_().sideEffect{x=it}.out('created').in('created').filter{it!=x}")
     public Iterable<Person> getCoCreators();
 
+    @GremlinGroovy("_().sideEffect{x=it}.out('created').in('created').filter{it!=x}.shuffle")
+    public Person getRandomCoCreators();
+
 }


### PR DESCRIPTION
I'm not sure if this has been mooted before, but it would be useful for me if the GremlinGroovy annotation worked for single item return types as well as Iterable<T>.

Currently, if a non-iterable type is used the result is a ClassCastError. This patch adds a check for whether the annotated method returns an iterable, and if not, processes just the first item it finds.
