### PR TITLE
With JDK 1.5, @Override can only be applied to methods overriding a supe...

### DIFF
--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -12,12 +12,10 @@ import java.lang.reflect.Proxy;
 
 public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> {
 
-    @Override
     public Class<Adjacency> getAnnotationType() {
         return Adjacency.class;
     }
 
-    @Override
     public Object processElement(final Adjacency annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);

--- a/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
@@ -11,12 +11,10 @@ import java.lang.reflect.Method;
 
 public class DomainAnnotationHandler implements AnnotationHandler<Domain> {
 
-    @Override
     public Class<Domain> getAnnotationType() {
         return Domain.class;
     }
 
-    @Override
     public Object processElement(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (element instanceof Edge) {
             return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);

--- a/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
@@ -15,12 +15,10 @@ import java.lang.reflect.Proxy;
 
 public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> {
 
-    @Override
     public Class<Incidence> getAnnotationType() {
         return Incidence.class;
     }
 
-    @Override
     public Object processElement(final Incidence annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);

--- a/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
@@ -12,12 +12,10 @@ import java.lang.reflect.Method;
 
 public class PropertyAnnotationHandler implements AnnotationHandler<Property> {
 
-    @Override
     public Class<Property> getAnnotationType() {
         return Property.class;
     }
 
-    @Override
     public Object processElement(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (ClassUtilities.isGetMethod(method)) {
             return element.getProperty(annotation.value());

--- a/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
@@ -11,12 +11,10 @@ import java.lang.reflect.Method;
 
 public class RangeAnnotationHandler implements AnnotationHandler<Range> {
 
-    @Override
     public Class<Range> getAnnotationType() {
         return Range.class;
     }
 
-    @Override
     public Object processElement(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (element instanceof Edge) {
             return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);

--- a/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
@@ -19,12 +19,10 @@ import java.lang.reflect.Method;
  */
 public class GremlinGroovyAnnotationHandler implements AnnotationHandler<GremlinGroovy> {
 
-    @Override
     public Class<GremlinGroovy> getAnnotationType() {
         return GremlinGroovy.class;
     }
 
-    @Override
     public Object processElement(final GremlinGroovy annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);


### PR DESCRIPTION
...rclass method

But not interface methods implementations,

This patch removes all @Override annotations from all interface methods implementations.
