### PR TITLE
Add interface to allow initialization of new framed vertices and edges.

### DIFF
--- a/src/main/java/com/tinkerpop/frames/FrameInitializer.java
+++ b/src/main/java/com/tinkerpop/frames/FrameInitializer.java
@@ -1,0 +1,16 @@
+package com.tinkerpop.frames;
+
+import com.tinkerpop.blueprints.Element;
+
+/**
+ * Allows new framed vertices and edges to be initialized before they are returned to the user. This can be used for defaulting of properties.
+ * @author Bryn Cooke
+ */
+public interface FrameInitializer {
+	/**
+	 * @param kind The kind of frame. 
+	 * @param framedGraph The graph.
+	 * @param element The new element that is being inserted into the graph.
+	 */
+	public void initElement(final Class<?> kind, final FramedGraph<?> framedGraph, final Element element);
+}

--- a/src/test/java/com/tinkerpop/frames/FramedInitializerTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedInitializerTest.java
@@ -1,0 +1,66 @@
+package com.tinkerpop.frames;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.impls.tg.TinkerGraphFactory;
+import com.tinkerpop.frames.domain.classes.Person;
+import com.tinkerpop.frames.domain.incidences.Knows;
+
+/**
+ * @author Bryn Cooke
+ */
+public class FramedInitializerTest {
+
+	private FramedGraph<Graph> framedGraph;
+
+	@Before
+	public void setup() {
+		Graph graph = TinkerGraphFactory.createTinkerGraph();
+		framedGraph = new FramedGraph<Graph>(graph);
+		framedGraph.registerFrameInitializer(nameDefaulter);
+		framedGraph.registerFrameInitializer(weightDefaulter);
+	}
+
+	@Test
+	public void testVertexInitialization() {
+		Person person = framedGraph.addVertex(null, Person.class);
+		assertEquals("Defaulted", person.getName());
+	}
+
+	@Test
+	public void testEdgeInitialization() {
+		Person person1 = framedGraph.addVertex(null, Person.class);
+		Person person2 = framedGraph.addVertex(null, Person.class);
+		person1.addKnows(person2);
+		assertEquals(Float.valueOf(1.0f), person1.getKnows().iterator().next().getWeight());
+	}
+
+	public static FrameInitializer nameDefaulter = new FrameInitializer() {
+
+		@Override
+		public void initElement(Class<?> kind, FramedGraph<?> framedGraph, Element element) {
+			if (kind == Person.class) {
+				assertNotNull(framedGraph);
+				element.setProperty("name", "Defaulted");
+			}
+		}
+	};
+
+	public static FrameInitializer weightDefaulter = new FrameInitializer() {
+
+		@Override
+		public void initElement(Class<?> kind, FramedGraph<?> framedGraph, Element element) {
+			assertNotNull(framedGraph);
+			if (kind == Knows.class) {
+				element.setProperty("weight", 1.0f);
+			}
+		}
+	};
+
+}


### PR DESCRIPTION
Allows clients to add an initializer that gets to mutate the graph whenever a new framed element is added to the graph.

Some sort of generic annotation defaulting mechanism could be built on this, but for now here is a simple example that default the weight property on a 'knows' edge.

``` java

FrameInitializer weightDefaulter = new FrameInitializer() {

        @Override
        public void initElement(Class<?> kind, FramedGraph<?> framedGraph, Element element) {
            assertNotNull(framedGraph);
            if (kind == Knows.class) {
                element.setProperty("weight", 1.0f);
            }
        }
    };

framedGraph.registerFrameInitializer(weightDefaulter);
```

This would allow someone to write an initializer to add type information https://github.com/tinkerpop/frames/issues/15

I am using this in a similar way in my own project where the an annotation on the class allows specifying of the security class of a vertex.

``` java
public class SecurityClassInitializer implements FrameInitializer {

    @Override
    public void initElement(Class<?> kind, FramedGraph<?> framedGraph, Element element) {
        SecurityClass securityClassAnnotation = kind.getAnnotation(SecurityClass.class);
        if(securityClassAnnotation != null) { 
            String securityClass = securityClassAnnotation.value();
            if(securityClass == null) { //Default to the class name.
                securityClass = kind.getName();
            }
            element.setProperty(SecureGraph.SECURITY_MODEL, securityClass);
        }
    }

}
```
