### PR TITLE
Add 'is' and 'can' prefixes to boolean 'get' methods

### DIFF
--- a/src/main/java/com/tinkerpop/frames/ClassUtilities.java
+++ b/src/main/java/com/tinkerpop/frames/ClassUtilities.java
@@ -1,19 +1,22 @@
 package com.tinkerpop.frames;
 
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Map;
+
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
 
 public class ClassUtilities {
     private static final String SET = "set";
     private static final String GET = "get";
     private static final String REMOVE = "remove";
     private static final String ADD = "add";
+    private static final String IS = "is";
+    private static final String CAN = "can";
 
     public static boolean isGetMethod(final Method method) {
-        return method.getName().startsWith(GET);
+    	Class<?> returnType = method.getReturnType();
+    	return (method.getName().startsWith(GET) || (returnType == Boolean.class || returnType == Boolean.TYPE) && (method.getName().startsWith(IS) || method.getName().startsWith(CAN)));
     }
 
     public static boolean isSetMethod(final Method method) {

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -340,5 +340,14 @@ public class FramedVertexTest extends TestCase {
         assertEquals(coauthors.size(), 2);
     }
 
-
+    
+    public void testBooleanGetMethods() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        marko.setBoolean(true);
+        assertTrue(marko.isBoolean());
+        assertTrue(marko.isBooleanPrimitive());
+        assertTrue(marko.canBoolean());
+        assertTrue(marko.canBooleanPrimitive());
+    }
+    
 }

--- a/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
+++ b/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
@@ -1,5 +1,7 @@
 package com.tinkerpop.frames.domain.classes;
 
+import java.util.Map;
+
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Incidence;
 import com.tinkerpop.frames.Property;
@@ -7,8 +9,6 @@ import com.tinkerpop.frames.annotations.gremlin.GremlinGroovy;
 import com.tinkerpop.frames.annotations.gremlin.GremlinParam;
 import com.tinkerpop.frames.domain.incidences.Created;
 import com.tinkerpop.frames.domain.incidences.Knows;
-
-import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -80,4 +80,20 @@ public interface Person extends NamedObject {
 
     @GremlinGroovy("it.as('x').out('created').in('created').except('x').groupCount.cap.next()")
     public Map<Person,Long> getRankedCoauthors();
+    
+    
+    @Property("boolean")
+    public void setBoolean(boolean b);
+    
+    @Property("boolean")
+    public boolean isBooleanPrimitive();
+    
+    @Property("boolean")
+    public Boolean isBoolean();
+    
+    @Property("boolean")
+    public boolean canBooleanPrimitive();
+    
+    @Property("boolean")
+    public Boolean canBoolean();
 }


### PR DESCRIPTION
Boolean get methods usually start with 'is' or 'can' rather than 'get'.

Now a frame can use more natural method names:

``` java
    @Property("boolean")
    public boolean isBooleanPrimitive();

    @Property("boolean")
    public boolean isBoolean();

    @Property("boolean")
    public boolean canBooleanPrimitive();

    @Property("boolean")
    public boolean canBoolean();
```
