### PR TITLE
All framed vertices now implement VertexFrame and all framed edges implement EdgeFrame.

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -15,6 +15,7 @@ h3. Version 2.3.0 (NOT OFFICIALLY RELEASED YET)
 </dependency>
 ```
 
+* All framed vertices now implement VertexFrame and all framed edges implement EdgeFrame. 
 * Internal package refactoring for organizational purposes (@annotations@ and @structures@)
 * Removed reference to sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl in @ClassUtilities@.
 * Added 'is' and 'can' prefixes for boolean methods that are marked as a 'get' method in @ClassUtilities@. 

--- a/src/main/java/com/tinkerpop/frames/FramedElement.java
+++ b/src/main/java/com/tinkerpop/frames/FramedElement.java
@@ -80,8 +80,10 @@ public class FramedElement implements InvocationHandler {
     }
 
     private Boolean proxyEquals(final Object other) {
-        if (Proxy.isProxyClass(other.getClass())) {
-            return this.element.equals(((FramedElement) (Proxy.getInvocationHandler(other))).getElement());
+        if (other instanceof VertexFrame) {
+            return this.element.equals(((VertexFrame) other).asVertex());
+        } if (other instanceof EdgeFrame) {
+            return this.element.equals(((EdgeFrame) other).asEdge());
         } else if (other instanceof Element) {
             return ElementHelper.areEqual(this.element, other);
         } else {

--- a/src/main/java/com/tinkerpop/frames/FramedGraph.java
+++ b/src/main/java/com/tinkerpop/frames/FramedGraph.java
@@ -1,5 +1,13 @@
 package com.tinkerpop.frames;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Features;
@@ -17,14 +25,6 @@ import com.tinkerpop.frames.annotations.RangeAnnotationHandler;
 import com.tinkerpop.frames.annotations.gremlin.GremlinGroovyAnnotationHandler;
 import com.tinkerpop.frames.structures.FramedEdgeIterable;
 import com.tinkerpop.frames.structures.FramedVertexIterable;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The primary class for interpreting/framing elements of a graph in terms of particulate annotated interfaces.
@@ -65,7 +65,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
      * @return a proxy objects backed by a vertex and interpreted from the perspective of the annotate interface
      */
     public <F> F frame(final Vertex vertex, final Class<F> kind) {
-        return (F) Proxy.newProxyInstance(kind.getClassLoader(), new Class[]{kind}, new FramedElement(this, vertex));
+        return (F) Proxy.newProxyInstance(kind.getClassLoader(), new Class[]{kind, VertexFrame.class}, new FramedElement(this, vertex));
     }
 
     /**
@@ -78,7 +78,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
      * @return an iterable of proxy objects backed by an edge and interpreted from the perspective of the annotate interface
      */
     public <F> F frame(final Edge edge, final Direction direction, final Class<F> kind) {
-        return (F) Proxy.newProxyInstance(kind.getClassLoader(), new Class[]{kind}, new FramedElement(this, edge, direction));
+        return (F) Proxy.newProxyInstance(kind.getClassLoader(), new Class[]{kind, EdgeFrame.class}, new FramedElement(this, edge, direction));
     }
 
     /**

--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -9,6 +9,7 @@ import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.ClassUtilities;
 import com.tinkerpop.frames.FramedElement;
 import com.tinkerpop.frames.FramedGraph;
+import com.tinkerpop.frames.VertexFrame;
 import com.tinkerpop.frames.structures.FramedVertexIterable;
 
 import java.lang.reflect.Method;
@@ -40,18 +41,18 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             }
         } else if (ClassUtilities.isAddMethod(method)) {
             if (adjacency.direction().equals(Direction.OUT))
-                framedGraph.getBaseGraph().addEdge(null, vertex, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), adjacency.label());
+                framedGraph.getBaseGraph().addEdge(null, vertex, ((VertexFrame) arguments[0]).asVertex(), adjacency.label());
             else
-                framedGraph.getBaseGraph().addEdge(null, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), vertex, adjacency.label());
+                framedGraph.getBaseGraph().addEdge(null, ((VertexFrame) arguments[0]).asVertex(), vertex, adjacency.label());
             return null;
         } else if (ClassUtilities.isRemoveMethod(method)) {
-            removeEdges(adjacency.direction(), adjacency.label(), vertex, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), framedGraph);
+            removeEdges(adjacency.direction(), adjacency.label(), vertex, ((VertexFrame) arguments[0]).asVertex(), framedGraph);
             return null;
         } else if (ClassUtilities.isSetMethod(method)) {
             removeEdges(adjacency.direction(), adjacency.label(), vertex, null, framedGraph);
             if (ClassUtilities.acceptsIterable(method)) {
                 for (Object o : (Iterable) arguments[0]) {
-                    Vertex v = (Vertex) ((FramedElement) Proxy.getInvocationHandler(o)).getElement();
+                    Vertex v = ((VertexFrame) o).asVertex();
                     if (adjacency.direction().equals(Direction.OUT)) {
                         framedGraph.getBaseGraph().addEdge(null, vertex, v, adjacency.label());
                     } else {
@@ -62,9 +63,9 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             } else {
                 if (null != arguments[0]) {
                     if (adjacency.direction().equals(Direction.OUT)) {
-                        framedGraph.getBaseGraph().addEdge(null, vertex, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), adjacency.label());
+                        framedGraph.getBaseGraph().addEdge(null, vertex, ((VertexFrame) arguments[0]).asVertex(), adjacency.label());
                     } else {
-                        framedGraph.getBaseGraph().addEdge(null, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), vertex, adjacency.label());
+                        framedGraph.getBaseGraph().addEdge(null, ((VertexFrame) arguments[0]).asVertex(), vertex, adjacency.label());
                     }
                 }
                 return null;

--- a/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
@@ -1,17 +1,16 @@
 package com.tinkerpop.frames.annotations;
 
+import java.lang.reflect.Method;
+
 import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.ClassUtilities;
-import com.tinkerpop.frames.structures.FramedEdgeIterable;
-import com.tinkerpop.frames.FramedElement;
+import com.tinkerpop.frames.EdgeFrame;
 import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.Incidence;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
+import com.tinkerpop.frames.VertexFrame;
+import com.tinkerpop.frames.structures.FramedEdgeIterable;
 
 public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> {
 
@@ -34,11 +33,11 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
             return new FramedEdgeIterable(framedGraph, element.getEdges(incidence.direction(), incidence.label()), incidence.direction(), ClassUtilities.getGenericClass(method));
         } else if (ClassUtilities.isAddMethod(method)) {
             if (incidence.direction().equals(Direction.OUT))
-                return framedGraph.addEdge(null, element, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), incidence.label(), Direction.OUT, method.getReturnType());
+                return framedGraph.addEdge(null, element, ((VertexFrame) arguments[0]).asVertex(), incidence.label(), Direction.OUT, method.getReturnType());
             else
-                return framedGraph.addEdge(null, (Vertex) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement(), element, incidence.label(), Direction.IN, method.getReturnType());
+                return framedGraph.addEdge(null, ((VertexFrame) arguments[0]).asVertex(), element, incidence.label(), Direction.IN, method.getReturnType());
         } else if (ClassUtilities.isRemoveMethod(method)) {
-            framedGraph.getBaseGraph().removeEdge((Edge) ((FramedElement) Proxy.getInvocationHandler(arguments[0])).getElement());
+            framedGraph.getBaseGraph().removeEdge(((EdgeFrame) arguments[0]).asEdge());
             return null;
         }
 

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -1,5 +1,12 @@
 package com.tinkerpop.frames;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
@@ -10,12 +17,6 @@ import com.tinkerpop.frames.domain.classes.Project;
 import com.tinkerpop.frames.domain.incidences.Created;
 import com.tinkerpop.frames.domain.incidences.CreatedBy;
 import com.tinkerpop.frames.domain.incidences.Knows;
-import junit.framework.TestCase;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -217,7 +218,6 @@ public class FramedVertexTest extends TestCase {
         }
         assertEquals(counter, 1);
 
-
         Project lop = framedGraph.frame(graph.getVertex(3), Project.class);
         counter = 0;
         List<CreatedBy> toRemove2 = new ArrayList<CreatedBy>();
@@ -263,7 +263,8 @@ public class FramedVertexTest extends TestCase {
         for (Edge edge : graph.getVertex(3).getEdges(Direction.IN, "created")) {
             if (edge.getLabel().equals("created")) {
                 counter++;
-                assertTrue(edge.getVertex(Direction.OUT).getProperty("name").equals("josh") || edge.getVertex(Direction.OUT).getProperty("name").equals("peter"));
+                assertTrue(edge.getVertex(Direction.OUT).getProperty("name").equals("josh")
+                        || edge.getVertex(Direction.OUT).getProperty("name").equals("peter"));
             }
         }
         assertEquals(counter, 2);
@@ -334,7 +335,6 @@ public class FramedVertexTest extends TestCase {
         assertEquals(coauthors.size(), 2);
     }
 
-
     public void testBooleanGetMethods() {
         Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
         marko.setBoolean(true);
@@ -342,6 +342,20 @@ public class FramedVertexTest extends TestCase {
         assertTrue(marko.isBooleanPrimitive());
         assertTrue(marko.canBoolean());
         assertTrue(marko.canBooleanPrimitive());
+    }
+
+    public void testFramingInterfaces() {
+        StanalonePerson marko = framedGraph.frame(graph.getVertex(1), StanalonePerson.class);
+        assertTrue(marko instanceof VertexFrame);
+        for (Knows knows : marko.getKnows()) {
+            assertTrue(knows instanceof EdgeFrame);
+        }
+    }
+
+    public static interface StanalonePerson {
+
+        @Incidence(label = "knows")
+        public Iterable<Knows> getKnows();
     }
 
 }


### PR DESCRIPTION
Irrespective of if the framed interface extends VertexFrame or EdgeFrame the proxy returned will always implement these interfaces.

This is prep work for https://github.com/tinkerpop/frames/pull/11 as annotation handlers no longer need to know about the method of framing (currently java proxy), instead they use VertexFrame or EdgeFrame.
