### PR TITLE
Throw UnsupportedOperationException calling 'add' or 'set' methods using @Incidence@ or @Adjacency@ if direction is set to 'BOTH'.

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -15,6 +15,7 @@ h3. Version 2.3.0 (NOT OFFICIALLY RELEASED YET)
 </dependency>
 ```
 
+* Throw unsupported operation exception calling 'add' or 'set' methods using @Incidence@ or @Adjacency@ if direction is set to 'BOTH'.
 * @Adjacency@ add methods with no parameter will return a new framed vertex using the return type of the method.
 * All framed vertices now implement VertexFrame and all framed edges implement EdgeFrame. 
 * Internal package refactoring for organizational purposes (@annotations@ and @structures@)

--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -46,15 +46,16 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             Vertex newVertex;
             Object returnValue = null;
             if (arguments == null) {
-                //Use this method to get the vertex so that the vertex initializer is called.
+                // Use this method to get the vertex so that the vertex
+                // initializer is called.
                 returnValue = framedGraph.addVertex(returnType, returnType);
                 newVertex = ((VertexFrame) returnValue).asVertex();
             } else {
                 newVertex = ((VertexFrame) arguments[0]).asVertex();
             }
-            
+
             addEdges(adjacency, framedGraph, vertex, newVertex);
-            
+
             if (returnType.isPrimitive()) {
                 return null;
             } else {
@@ -85,10 +86,15 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
     }
 
     private void addEdges(final Adjacency adjacency, final FramedGraph framedGraph, final Vertex vertex, Vertex newVertex) {
-        if (adjacency.direction().equals(Direction.OUT)) {
+        switch(adjacency.direction()) {
+        case OUT:
             framedGraph.getBaseGraph().addEdge(null, vertex, newVertex, adjacency.label());
-        } else {
-            framedGraph.getBaseGraph().addEdge(null, newVertex, vertex, adjacency.label());
+            break;
+        case IN:
+            framedGraph.getBaseGraph().addEdge(null, vertex, newVertex, adjacency.label());
+            break;
+        case BOTH:
+            throw new UnsupportedOperationException("Direction.BOTH it not supported on 'add' or 'set' methods");
         }
     }
 

--- a/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
@@ -32,10 +32,16 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
         if (ClassUtilities.isGetMethod(method)) {
             return new FramedEdgeIterable(framedGraph, element.getEdges(incidence.direction(), incidence.label()), incidence.direction(), ClassUtilities.getGenericClass(method));
         } else if (ClassUtilities.isAddMethod(method)) {
-            if (incidence.direction().equals(Direction.OUT))
+            
+            switch(incidence.direction()) {
+            case OUT:
                 return framedGraph.addEdge(null, element, ((VertexFrame) arguments[0]).asVertex(), incidence.label(), Direction.OUT, method.getReturnType());
-            else
+            case IN:
                 return framedGraph.addEdge(null, ((VertexFrame) arguments[0]).asVertex(), element, incidence.label(), Direction.IN, method.getReturnType());
+            case BOTH:
+                throw new UnsupportedOperationException("Direction.BOTH it not supported on 'add' or 'set' methods");
+            }
+                
         } else if (ClassUtilities.isRemoveMethod(method)) {
             framedGraph.getBaseGraph().removeEdge(((EdgeFrame) arguments[0]).asEdge());
             return null;

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -388,4 +388,26 @@ public class FramedVertexTest {
         public Iterable<Knows> getKnows();
     }
 
+    @Test(expected=UnsupportedOperationException.class)
+    public void testAddAdjacencyBothError() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Person peter = framedGraph.frame(graph.getVertex(6), Person.class);
+        marko.addKnowsPersonDirectionBothError(peter);
+        
+    }
+    
+    
+    @Test(expected=UnsupportedOperationException.class)
+    public void testSetAdjacencyBothError() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Person peter = framedGraph.frame(graph.getVertex(6), Person.class);
+        marko.setKnowsPersonDirectionBothError(peter);
+    }
+    
+    @Test(expected=UnsupportedOperationException.class)
+    public void testAddIncidenceBothError() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Project rdfAgents = framedGraph.frame(graph.addVertex(null), Project.class);
+        marko.addCreatedDirectionBothError(rdfAgents);
+    }
 }

--- a/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
+++ b/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
@@ -1,5 +1,6 @@
 package com.tinkerpop.frames.domain.classes;
 
+import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Incidence;
 import com.tinkerpop.frames.Property;
@@ -98,4 +99,13 @@ public interface Person extends NamedObject {
 
     @Property("boolean")
     public Boolean canBoolean();
+    
+    @Adjacency(label = "knows", direction=Direction.BOTH)
+    public void addKnowsPersonDirectionBothError(final Person person);
+    
+    @Adjacency(label = "knows", direction=Direction.BOTH)
+    public void setKnowsPersonDirectionBothError(final Person person);
+    
+    @Incidence(label = "created", direction=Direction.BOTH)
+    public Created addCreatedDirectionBothError(final Project project);
 }


### PR DESCRIPTION
Fix for https://github.com/tinkerpop/frames/issues/33
Code like this will now throw an UnsupportedOperationException:

``` java
    @Adjacency(label = "knows", direction=Direction.BOTH)
    public void addKnowsPersonDirectionBothError(final Person person);

    @Adjacency(label = "knows", direction=Direction.BOTH)
    public void setKnowsPersonDirectionBothError(final Person person);

    @Incidence(label = "created", direction=Direction.BOTH)
    public Created addCreatedDirectionBothError(final Project project);
```

Previously this would have behaved in the same way as Direction.IN
