### PR TITLE
Clients can now start their annotation script with anything rather than just 'it' or '_()'

### DIFF
--- a/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
  * @author Bryn Cooke
  */
 public class GremlinGroovyAnnotationHandler implements AnnotationHandler<GremlinGroovy> {
+    private static final String PIPE = "_()";
     private final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine();
     private static final String IT = "it";
     private static final String G = "g";
@@ -56,7 +57,7 @@ public class GremlinGroovyAnnotationHandler implements AnnotationHandler<Gremlin
             final Object result = script.eval(bindings);
 
             // TODO: Deprecate the use of _() and replace with it
-            if (result instanceof Pipe & !annotation.value().startsWith(IT)) {
+            if (result instanceof Pipe & annotation.value().startsWith(PIPE)) {
                 LOGGER.warning("_() is deprecated in favor of using 'it' to represent the framed vertex");
                 ((Pipe) result).setStarts(new SingleIterator<Element>(vertex));
             }

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -334,11 +334,18 @@ public class FramedVertexTest {
 
     @Test
     public void testGetGremlinGroovyParameters() {
+        Person josh = framedGraph.frame(graph.getVertex(4), Person.class);
         Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Person peter = framedGraph.frame(graph.getVertex(6), Person.class);
+        Project project = framedGraph.frame(graph.getVertex(6), Project.class);
+        
         Person coCreator = marko.getCoCreatorOfAge(32);
-        assertTrue(coCreator.getName().equals("josh"));
+        assertEquals(josh, coCreator);
         coCreator = marko.getCoCreatorOfAge(35);
-        assertTrue(coCreator.getName().equals("peter"));
+        assertEquals(peter, coCreator);
+        
+        Iterable<Person> known = marko.getKnownRootedFromParam(josh);
+        assertEquals(marko, known.iterator().next());
     }
 
     @Test
@@ -410,4 +417,6 @@ public class FramedVertexTest {
         Project rdfAgents = framedGraph.frame(graph.addVertex(null), Project.class);
         marko.addCreatedDirectionBothError(rdfAgents);
     }
+    
+    
 }

--- a/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
+++ b/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
@@ -84,6 +84,9 @@ public interface Person extends NamedObject {
 
     @GremlinGroovy("it.as('x').out('created').in('created').except('x').groupCount.cap.next()")
     public Map<Person, Long> getRankedCoauthors();
+    
+    @GremlinGroovy("person.asVertex().in('knows')")
+    public Iterable<Person> getKnownRootedFromParam(@GremlinParam("person") Person person);
 
     @Deprecated
     @GremlinGroovy("_().out('knows')")


### PR DESCRIPTION
Slight modification to https://github.com/tinkerpop/frames/issues/26

This means that they start a query at parameter or declare a collection for use in the gremlin except retain pattern:

``` java
    @GremlinGroovy("person.asVertex().in('knows')")
    public Iterable<Person> getKnownRootedFromParam(@GremlinParam("person") Person person);
```

I've not updated the changelog as I believe this is part of 'Deprecated the use of @_()@ in favor of @it@ in @@GremlinGroovy@'
