### PR TITLE
Fix adjacency handler for adding relationships with Direction.IN

### DIFF
--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -53,7 +53,6 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             } else {
                 newVertex = ((VertexFrame) arguments[0]).asVertex();
             }
-
             addEdges(adjacency, framedGraph, vertex, newVertex);
 
             if (returnType.isPrimitive()) {
@@ -91,7 +90,7 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             framedGraph.getBaseGraph().addEdge(null, vertex, newVertex, adjacency.label());
             break;
         case IN:
-            framedGraph.getBaseGraph().addEdge(null, vertex, newVertex, adjacency.label());
+            framedGraph.getBaseGraph().addEdge(null, newVertex, vertex, adjacency.label());
             break;
         case BOTH:
             throw new UnsupportedOperationException("Direction.BOTH it not supported on 'add' or 'set' methods");

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -417,6 +417,13 @@ public class FramedVertexTest {
         Project rdfAgents = framedGraph.frame(graph.addVertex(null), Project.class);
         marko.addCreatedDirectionBothError(rdfAgents);
     }
-    
-    
+
+    @Test
+    public void testAddIncidenceIn() {
+        Person marko = framedGraph.frame(graph.getVertex(1), Person.class);
+        Project rdfAgents = framedGraph.frame(graph.addVertex(null), Project.class);
+        rdfAgents.addCreatedByPeople(marko);
+        assertTrue(rdfAgents.getCreatedByPeople().iterator().hasNext());
+        assertEquals(marko, rdfAgents.getCreatedByPeople().iterator().next());
+    }
 }

--- a/src/test/java/com/tinkerpop/frames/domain/classes/Project.java
+++ b/src/test/java/com/tinkerpop/frames/domain/classes/Project.java
@@ -25,5 +25,8 @@ public interface Project extends NamedObject {
 
     @Incidence(label = "created", direction = Direction.IN)
     public void removeCreatedBy(CreatedBy createdBy);
+
+    @Adjacency(label = "created", direction = Direction.IN)
+    public void addCreatedByPeople(final Person person);
 }
 


### PR DESCRIPTION
Currently the relationships get set with Direction.OUT regardless of
what's specified on the annotation. A test for adding relationships
with an inward direction has also been added.
