### PR TITLE
Fix detection of parameterized return types

### DIFF
--- a/src/main/java/com/tinkerpop/frames/ClassUtilities.java
+++ b/src/main/java/com/tinkerpop/frames/ClassUtilities.java
@@ -5,6 +5,7 @@ import com.tinkerpop.blueprints.Vertex;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Map;
 
 
@@ -52,9 +53,13 @@ public class ClassUtilities {
     @SuppressWarnings("rawtypes")
     public static Class getGenericClass(final Method method) {
         final Type returnType = method.getGenericReturnType();
-        if (returnType instanceof ParameterizedType)
-            return (Class) ((ParameterizedType) returnType).getActualTypeArguments()[0];
-        else
+        if (returnType instanceof ParameterizedType) {
+        	Type type = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+        	if (type instanceof TypeVariable) {
+        		return (Class)((TypeVariable)type).getBounds()[0];
+        	} else
+        		return (Class)type;
+        } else
             return method.getReturnType();
     }
 }

--- a/src/test/java/com/tinkerpop/frames/ClassUtilitiesTest.java
+++ b/src/test/java/com/tinkerpop/frames/ClassUtilitiesTest.java
@@ -1,0 +1,15 @@
+package com.tinkerpop.frames;
+
+import junit.framework.TestCase;
+
+public class ClassUtilitiesTest extends TestCase {
+    public void testGetGenericClassForParametrizedType() throws SecurityException, NoSuchMethodException {
+    	assertEquals(Clazz.class, ClassUtilities.getGenericClass(ClassUtilitiesTest.class.getMethod("getSomething", Class.class)));
+    }
+    
+    public static class Clazz {}
+    
+    public <T extends Clazz> Iterable<T> getSomething(Class<T> clazz) {
+    	return null;
+    }
+}


### PR DESCRIPTION
This fixes the detection of the return type when a method declaration like this is used in a frame:

&lt;T extends Animal&gt; Iterable&lt;T&gt; getPets(Class&lt;T&gt; typeOfPet);

Such declarations currently lead to a classcastexception in ClassUtilities.

Such declarations are very useful for the new polymorphism support (see tinkerpop/frames#49), where the argument can be used by GremlinGroovy annotated to actually filter on that type, and restrain the results to the specific type. This fix however has no relation to the polymorphism support, just a bugfix for something not properly covered by ClassUtilities.
