### PR TITLE
Drop direction from the FramedGraph.frameEdge methods

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -15,6 +15,7 @@ h3. Version 2.4.0 (NOT OFFICIALLY RELEASED YET)
 </dependency>
 ```
 
+* The direction parameter is dropped for framing Edges from FramedGraph.frame
 * Fixed NPE when enum property type set to null
 * Inheritance/Poymorphism support
 * Factory/Module support

--- a/src/main/java/com/tinkerpop/frames/FramedElement.java
+++ b/src/main/java/com/tinkerpop/frames/FramedElement.java
@@ -18,7 +18,6 @@ import java.util.Map;
  */
 public class FramedElement implements InvocationHandler {
 
-    private final Direction direction;
     protected final FramedGraph framedGraph;
     protected final Element element;
     private static Method hashCodeMethod;
@@ -41,7 +40,7 @@ public class FramedElement implements InvocationHandler {
         }
     }
 
-    public FramedElement(final FramedGraph framedGraph, final Element element, final Direction direction) {
+    public FramedElement(final FramedGraph framedGraph, final Element element) {
         if (null == framedGraph) {
             throw new IllegalArgumentException("FramedGraph can not be null");
         }
@@ -52,11 +51,6 @@ public class FramedElement implements InvocationHandler {
 
         this.element = element;
         this.framedGraph = framedGraph;
-        this.direction = direction;
-    }
-
-    public FramedElement(final FramedGraph framedGraph, final Element element) {
-        this(framedGraph, element, null);
     }
 
     public Object invoke(final Object proxy, final Method method, final Object[] arguments) {
@@ -76,7 +70,7 @@ public class FramedElement implements InvocationHandler {
         for (final Annotation annotation : annotations) {
 			AnnotationHandler annotationHandler = annotationHandlers.get(annotation.annotationType());
             if (annotationHandler != null) {
-                return annotationHandler.processElement(annotation, method, arguments, this.framedGraph, this.element, this.direction);
+                return annotationHandler.processElement(annotation, method, arguments, this.framedGraph, this.element);
             }
         }
 

--- a/src/main/java/com/tinkerpop/frames/FramedGraph.java
+++ b/src/main/java/com/tinkerpop/frames/FramedGraph.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Features;
 import com.tinkerpop.blueprints.Graph;
@@ -113,8 +112,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 	 * @return an iterable of proxy objects backed by an edge and interpreted
 	 *         from the perspective of the annotate interface
 	 */
-	public <F> F frame(final Edge edge, final Direction direction,
-			final Class<F> kind) {
+	public <F> F frame(final Edge edge, final Class<F> kind) {
 		Collection<Class<?>> resolvedTypes = new HashSet<Class<?>>();
 		resolvedTypes.add(EdgeFrame.class);
 		resolvedTypes.add(kind);
@@ -124,7 +122,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 		}
 		return (F) Proxy.newProxyInstance(kind.getClassLoader(),
 				resolvedTypes.toArray(new Class[resolvedTypes.size()]),
-				new FramedElement(this, edge, direction));
+				new FramedElement(this, edge));
 	}
 
 	/**
@@ -158,9 +156,8 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 	 * @return an iterable of proxy objects backed by an edge and interpreted
 	 *         from the perspective of the annotate interface
 	 */
-	public <F> Iterable<F> frameEdges(final Iterable<Edge> edges,
-			final Direction direction, final Class<F> kind) {
-		return new FramedEdgeIterable<F>(this, edges, direction, kind);
+	public <F> Iterable<F> frameEdges(final Iterable<Edge> edges, final Class<F> kind) {
+		return new FramedEdgeIterable<F>(this, edges, kind);
 	}
 
 	public Vertex getVertex(final Object id) {
@@ -225,9 +222,8 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 	 * @return a proxy object backed by the edge and interpreted from the
 	 *         perspective of the annotate interface
 	 */
-	public <F> F getEdge(final Object id, final Direction direction,
-			final Class<F> kind) {
-		return this.frame(config.getConfiguredGraph().getEdge(id), direction, kind);
+	public <F> F getEdge(final Object id, final Class<F> kind) {
+		return this.frame(config.getConfiguredGraph().getEdge(id), kind);
 	}
 
 	public Edge addEdge(final Object id, final Vertex outVertex,
@@ -257,12 +253,12 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 	 */
 	public <F> F addEdge(final Object id, final Vertex outVertex,
 			final Vertex inVertex, final String label,
-			final Direction direction, final Class<F> kind) {
+			final Class<F> kind) {
 		Edge edge = config.getConfiguredGraph().addEdge(id, outVertex, inVertex, label);
 		for (FrameInitializer initializer : config.getFrameInitializers()) {
 			initializer.initElement(kind, this, edge);
 		}
-		return this.frame(edge, direction, kind);
+		return this.frame(edge, kind);
 	}
 
 	public void removeVertex(final Vertex vertex) {
@@ -326,9 +322,9 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 	 *         from the perspective of the annotate interface
 	 */
 	public <F> Iterable<F> getEdges(final String key, final Object value,
-			final Direction direction, final Class<F> kind) {
+			final Class<F> kind) {
 		return new FramedEdgeIterable<F>(this, config.getConfiguredGraph().getEdges(key,
-				value), direction, kind);
+				value), kind);
 	}
 
 	public Features getFeatures() {

--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -21,7 +21,7 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
 
     @Override
     public Object processElement(final Adjacency annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph,
-            final Element element, final Direction direction) {
+            final Element element) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
         } else {

--- a/src/main/java/com/tinkerpop/frames/annotations/AnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AnnotationHandler.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames.annotations;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.frames.FramedGraph;
 
@@ -10,5 +9,5 @@ import java.lang.reflect.Method;
 public interface AnnotationHandler<T extends Annotation> {
     public Class<T> getAnnotationType();
 
-    public Object processElement(final T annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction);
+    public Object processElement(final T annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element);
 }

--- a/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/DomainAnnotationHandler.java
@@ -16,16 +16,16 @@ public class DomainAnnotationHandler implements AnnotationHandler<Domain> {
     }
 
     @Override
-    public Object processElement(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+    public Object processElement(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element) {
         if (element instanceof Edge) {
-            return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);
+            return processEdge(annotation, method, arguments, framedGraph, (Edge) element);
         } else {
             throw new UnsupportedOperationException();
         }
     }
 
-    public Object processEdge(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
-        return framedGraph.frame(edge.getVertex(direction), method.getReturnType());
+    public Object processEdge(final Domain annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge) {
+        return framedGraph.frame(edge.getVertex(Direction.OUT), method.getReturnType());
     }
 
 }

--- a/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/IncidenceAnnotationHandler.java
@@ -2,7 +2,6 @@ package com.tinkerpop.frames.annotations;
 
 import java.lang.reflect.Method;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.ClassUtilities;
@@ -20,7 +19,7 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
     }
 
     @Override
-    public Object processElement(final Incidence annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+    public Object processElement(final Incidence annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
         } else {
@@ -30,14 +29,14 @@ public class IncidenceAnnotationHandler implements AnnotationHandler<Incidence> 
 
     public Object processVertex(final Incidence incidence, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Vertex element) {
         if (ClassUtilities.isGetMethod(method)) {
-            return new FramedEdgeIterable(framedGraph, element.getEdges(incidence.direction(), incidence.label()), incidence.direction(), ClassUtilities.getGenericClass(method));
+            return new FramedEdgeIterable(framedGraph, element.getEdges(incidence.direction(), incidence.label()), ClassUtilities.getGenericClass(method));
         } else if (ClassUtilities.isAddMethod(method)) {
             
             switch(incidence.direction()) {
             case OUT:
-                return framedGraph.addEdge(null, element, ((VertexFrame) arguments[0]).asVertex(), incidence.label(), Direction.OUT, method.getReturnType());
+                return framedGraph.addEdge(null, element, ((VertexFrame) arguments[0]).asVertex(), incidence.label(), method.getReturnType());
             case IN:
-                return framedGraph.addEdge(null, ((VertexFrame) arguments[0]).asVertex(), element, incidence.label(), Direction.IN, method.getReturnType());
+                return framedGraph.addEdge(null, ((VertexFrame) arguments[0]).asVertex(), element, incidence.label(), method.getReturnType());
             case BOTH:
                 throw new UnsupportedOperationException("Direction.BOTH it not supported on 'add' or 'set' methods");
             }

--- a/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/PropertyAnnotationHandler.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames.annotations;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.frames.ClassUtilities;
 import com.tinkerpop.frames.FramedGraph;
@@ -16,7 +15,7 @@ public class PropertyAnnotationHandler implements AnnotationHandler<Property> {
     }
 
     @Override
-    public Object processElement(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+    public Object processElement(final Property annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element) {
         if (ClassUtilities.isGetMethod(method)) {
             Object value = element.getProperty(annotation.value());
             if (method.getReturnType().isEnum())

--- a/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/RangeAnnotationHandler.java
@@ -16,16 +16,16 @@ public class RangeAnnotationHandler implements AnnotationHandler<Range> {
     }
 
     @Override
-    public Object processElement(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element, final Direction direction) {
+    public Object processElement(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Element element) {
         if (element instanceof Edge) {
-            return processEdge(annotation, method, arguments, framedGraph, (Edge) element, direction);
+            return processEdge(annotation, method, arguments, framedGraph, (Edge) element);
         } else {
             throw new UnsupportedOperationException();
         }
     }
 
-    public Object processEdge(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge, final Direction direction) {
-        return framedGraph.frame(edge.getVertex(direction.opposite()), method.getReturnType());
+    public Object processEdge(final Range annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph, final Edge edge) {
+        return framedGraph.frame(edge.getVertex(Direction.IN), method.getReturnType());
     }
 
 }

--- a/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/gremlin/GremlinGroovyAnnotationHandler.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames.annotations.gremlin;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.ClassUtilities;
@@ -43,7 +42,7 @@ public class GremlinGroovyAnnotationHandler implements AnnotationHandler<Gremlin
 
     @Override
     public Object processElement(final GremlinGroovy annotation, final Method method, final Object[] arguments, final FramedGraph framedGraph,
-                                 final Element element, final Direction direction) {
+                                 final Element element) {
         if (element instanceof Vertex) {
             return processVertex(annotation, method, arguments, framedGraph, (Vertex) element);
         } else {

--- a/src/main/java/com/tinkerpop/frames/structures/FramedEdgeIterable.java
+++ b/src/main/java/com/tinkerpop/frames/structures/FramedEdgeIterable.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames.structures;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.frames.FramedGraph;
@@ -12,15 +11,13 @@ import java.util.Iterator;
  */
 public class FramedEdgeIterable<T> implements Iterable<T> {
     protected final Class<T> kind;
-    protected final Direction direction;
     protected final Iterable<Edge> iterable;
     protected final FramedGraph<? extends Graph> framedGraph;
 
-    public FramedEdgeIterable(final FramedGraph<? extends Graph> framedGraph, final Iterable<Edge> iterable, final Direction direction, final Class<T> kind) {
+    public FramedEdgeIterable(final FramedGraph<? extends Graph> framedGraph, final Iterable<Edge> iterable, final Class<T> kind) {
         this.framedGraph = framedGraph;
         this.iterable = iterable;
         this.kind = kind;
-        this.direction = direction;
     }
 
     public Iterator<T> iterator() {
@@ -37,7 +34,7 @@ public class FramedEdgeIterable<T> implements Iterable<T> {
             }
 
             public T next() {
-                return framedGraph.frame(this.iterator.next(), direction, kind);
+                return framedGraph.frame(this.iterator.next(), kind);
             }
         };
     }

--- a/src/test/java/com/tinkerpop/frames/FramedEdgeTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedEdgeTest.java
@@ -25,7 +25,7 @@ public class FramedEdgeTest extends TestCase {
 
         Person marko = framedGraph.getVertex(1, Person.class);
         Person vadas = framedGraph.getVertex(2, Person.class);
-        Knows knows = framedGraph.getEdge(7, Direction.OUT, Knows.class);
+        Knows knows = framedGraph.getEdge(7, Knows.class);
         assertEquals(marko, knows.getDomain());
         assertEquals(vadas, knows.getRange());
 
@@ -40,7 +40,7 @@ public class FramedEdgeTest extends TestCase {
         FramedGraph<Graph> framedGraph = new FramedGraph<Graph>(graph);
 
         Iterator<Edge> edges = framedGraph.getEdges("weight", 0.4f).iterator();
-        Iterator<Created> createds = framedGraph.getEdges("weight", 0.4f, Direction.OUT, Created.class).iterator();
+        Iterator<Created> createds = framedGraph.getEdges("weight", 0.4f, Created.class).iterator();
 
         int counter = 0;
         while (edges.hasNext()) {
@@ -57,8 +57,8 @@ public class FramedEdgeTest extends TestCase {
         Graph graph = TinkerGraphFactory.createTinkerGraph();
         FramedGraph<Graph> framedGraph = new FramedGraph<Graph>(graph);
 
-        Iterator<Created> createds1 = framedGraph.frameEdges(framedGraph.getEdges("weight", 0.4f), Direction.OUT, Created.class).iterator();
-        Iterator<Created> createds2 = framedGraph.getEdges("weight", 0.4f, Direction.OUT, Created.class).iterator();
+        Iterator<Created> createds1 = framedGraph.frameEdges(framedGraph.getEdges("weight", 0.4f), Created.class).iterator();
+        Iterator<Created> createds2 = framedGraph.getEdges("weight", 0.4f, Created.class).iterator();
 
         int counter = 0;
         while (createds1.hasNext()) {
@@ -78,7 +78,7 @@ public class FramedEdgeTest extends TestCase {
         Person marko = framedGraph.getVertex(1, Person.class);
         Person vadas = framedGraph.getVertex(2, Person.class);
         Created created = marko.getCreated().iterator().next();
-        WeightedEdge weightedEdge = framedGraph.frame(created.asEdge(), Direction.OUT, WeightedEdge.class);
+        WeightedEdge weightedEdge = framedGraph.frame(created.asEdge(), WeightedEdge.class);
 
         assertEquals(created, weightedEdge);
     }

--- a/src/test/java/com/tinkerpop/frames/FramedElementTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedElementTest.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraphFactory;
@@ -27,11 +26,15 @@ public class FramedElementTest extends TestCase {
         assertEquals(lop.getName(), "lop");
         assertEquals(lop.getLanguage(), "java");
 
-        Created markoCreatedLop = framedGraph.getEdge(9, Direction.OUT, Created.class);
+        Created markoCreatedLop = framedGraph.getEdge(9, Created.class);
         assertEquals(markoCreatedLop.getWeight(), 0.4f);
+        assertEquals(marko, markoCreatedLop.getDomain());
+        assertEquals(lop, markoCreatedLop.getRange());
 
-        CreatedBy lopCreatedByMarko = framedGraph.getEdge(9, Direction.IN, CreatedBy.class);
+        CreatedBy lopCreatedByMarko = framedGraph.getEdge(9, CreatedBy.class);
         assertEquals(lopCreatedByMarko.getWeight(), 0.4f);
+        assertEquals(lop, lopCreatedByMarko.getDomain());
+        assertEquals(marko, lopCreatedByMarko.getRange());
 
         Person temp = framedGraph.frame(graph.addVertex(null), Person.class);
         assertNull(temp.getName());
@@ -51,7 +54,7 @@ public class FramedElementTest extends TestCase {
         marko.setAge(31);
         assertEquals(marko.getAge(), new Integer(31));
 
-        Created markoCreatedLop = framedGraph.getEdge(9, Direction.OUT, Created.class);
+        Created markoCreatedLop = framedGraph.getEdge(9, Created.class);
         assertEquals(markoCreatedLop.getWeight(), 0.4f);
         markoCreatedLop.setWeight(99.0f);
         assertEquals(markoCreatedLop.getWeight(), 99.0f);
@@ -100,7 +103,7 @@ public class FramedElementTest extends TestCase {
         Person marko = framedGraph.getVertex(1, Person.class);
         assertEquals("v[1]", marko.toString());
 
-        Created markoCreatedLop = framedGraph.getEdge(9, Direction.OUT, Created.class);
+        Created markoCreatedLop = framedGraph.getEdge(9, Created.class);
         assertEquals("e[9][1-created->3]", markoCreatedLop.toString());
     }
 

--- a/src/test/java/com/tinkerpop/frames/FramedGraphTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedGraphTest.java
@@ -48,7 +48,7 @@ public class FramedGraphTest extends GraphTest {
         FramedGraph<Graph> framedGraph = new FramedGraph<Graph>(graph);
 
         assertEquals(framedGraph.frame(graph.getVertex(1), Person.class), framedGraph.getVertex(1, Person.class));
-        assertEquals(framedGraph.frame(graph.getEdge(7), Direction.OUT, Knows.class), framedGraph.getEdge(7, Direction.OUT, Knows.class));
+        assertEquals(framedGraph.frame(graph.getEdge(7), Knows.class), framedGraph.getEdge(7, Knows.class));
     }
 
     public void testFrameVertices() {

--- a/src/test/java/com/tinkerpop/frames/domain/incidences/Created.java
+++ b/src/test/java/com/tinkerpop/frames/domain/incidences/Created.java
@@ -12,10 +12,10 @@ import com.tinkerpop.frames.domain.classes.Project;
  */
 public interface Created extends EdgeFrame {
     @Domain
-    public Project getDomain();
+    public Person getDomain();
 
     @Range
-    public Person getRange();
+    public Project getRange();
 
     @Property("weight")
     public Float getWeight();

--- a/src/test/java/com/tinkerpop/frames/domain/incidences/CreatedBy.java
+++ b/src/test/java/com/tinkerpop/frames/domain/incidences/CreatedBy.java
@@ -10,11 +10,14 @@ import com.tinkerpop.frames.domain.classes.Project;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public interface CreatedBy {
-
-    @Domain
+	// Domain and Range are respective to the actual edge, which is a "created" edge, with a Person
+	// at the domain side. So the Person is the domain here, because it is the domain (source) of the
+	// "created" edge.
+	// Typically you would call these methods getPerson() and getProject() to avoid confusion.
+	@Range
     public Project getDomain();
 
-    @Range
+    @Domain
     public Person getRange();
 
     @Property("weight")

--- a/src/test/java/com/tinkerpop/frames/typed/TypedGraphModuleTest.java
+++ b/src/test/java/com/tinkerpop/frames/typed/TypedGraphModuleTest.java
@@ -2,7 +2,6 @@ package com.tinkerpop.frames.typed;
 
 import junit.framework.TestCase;
 
-import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
@@ -69,8 +68,8 @@ public class TypedGraphModuleTest extends TestCase {
 		FramedGraph<Graph> framedGraph = factory.create(graph);
 		Vertex v1 = graph.addVertex(null);
 		Vertex v2 = graph.addVertex(null);
-		A a = framedGraph.addEdge(null, v1, v2, "label", Direction.OUT, A.class);
-		C c = framedGraph.addEdge(null, v1, v2, "label", Direction.OUT, C.class);
+		A a = framedGraph.addEdge(null, v1, v2, "label", A.class);
+		C c = framedGraph.addEdge(null, v1, v2, "label", C.class);
 		assertEquals("A", ((EdgeFrame) a).asEdge().getProperty("type"));
 		assertEquals("C", ((EdgeFrame) c).asEdge().getProperty("type"));
 	}
@@ -84,7 +83,7 @@ public class TypedGraphModuleTest extends TestCase {
 		Vertex v2 = graph.addVertex(null);
 		Edge cE = graph.addEdge(null, v1, v2, "label");
 		cE.setProperty("type", "C");
-		Base c = framedGraph.getEdge(cE.getId(), Direction.OUT, Base.class);
+		Base c = framedGraph.getEdge(cE.getId(), Base.class);
 		assertTrue(c instanceof C);
 	}
 }


### PR DESCRIPTION
See also
https://groups.google.com/forum/?fromgroups#!topic/gremlin-users/PDFkieldxFo

The FramedGraph.frameEdge methods have a Direction parameter to
define which side of the frame is the domain (source) and which side
the range (target) of the framed-edge. This is confusing, because
an edge already has a direction that defines source and target of the
frame.

Moreover, it seems of little use to be able to change the direction
of a framed edge at runtime: The framed type has a natural
direction (e.g. Knows vs. IsKnownBy, or Created vs. IsCreatedBy).
This is most apparent when both sides of the edge are of different type
(e.g. Person - Created - Project, vs. Project - CreatedBy - Person).
Passing the wrong direction at runtime will just result in a
ClassCastException.

The direction parameter also makes it hard to generalize the framing of
elements, because for edges you need additional parameters. E.g. it
will be very easy to implement edge-support for GremlinGroovy
annotations (currently GremlinGroovy only supports vertices as input and
output), once the direction parameter is gone.

The direction parameter is only used by the @Domain and @Range
annotations. This commit change the behavior of these annotations to
use the direction of the edge itself, instead of what's passed at
runtime.
