### PR TITLE
addAdjacency id fix

### DIFF
--- a/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
+++ b/src/main/java/com/tinkerpop/frames/annotations/AdjacencyAnnotationHandler.java
@@ -45,7 +45,7 @@ public class AdjacencyAnnotationHandler implements AnnotationHandler<Adjacency> 
             if (arguments == null) {
                 // Use this method to get the vertex so that the vertex
                 // initializer is called.
-                returnValue = framedGraph.addVertex(returnType, returnType);
+                returnValue = framedGraph.addVertex(null, returnType);
                 newVertex = ((VertexFrame) returnValue).asVertex();
             } else {
                 newVertex = ((VertexFrame) arguments[0]).asVertex();

--- a/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
+++ b/src/test/java/com/tinkerpop/frames/FramedVertexTest.java
@@ -1,5 +1,6 @@
 package com.tinkerpop.frames;
 
+import com.google.common.collect.Sets;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
@@ -16,11 +17,16 @@ import com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -256,6 +262,14 @@ public class FramedVertexTest {
         assertEquals(2, counter);
 
 
+    }
+
+    @Test
+    public void testAddingTwoAdjacencies() {
+        Person person = framedGraph.addVertex(null, Person.class);
+        HashSet<Person> people = Sets.newHashSet(person.addKnowsNewPerson(),
+                                                 person.addKnowsNewPerson());
+        assertEquals(people, Sets.newHashSet(person.getKnowsPeople()));
     }
     
     @Test


### PR DESCRIPTION
When using the @Adjancency annotation with an addNewThing() method you
get a new object with the object's class as its id in the graph.  I
changed the id to null so the underlying graph would set the id instead.

I also added a test that adds two vertexes using addKnowsNewPerson.
This would have failed without the above fix, because it would try two
add two Person vertexes with the same id (Person.class).
