### PR TITLE
optimized JavaHandlerModule and JavaFrameInitializer

### DIFF
--- a/src/main/java/com/tinkerpop/frames/modules/javahandler/JavaFrameInitializer.java
+++ b/src/main/java/com/tinkerpop/frames/modules/javahandler/JavaFrameInitializer.java
@@ -6,13 +6,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.FrameInitializer;
 import com.tinkerpop.frames.FramedGraph;
 import com.tinkerpop.frames.util.ExceptionUtils;
+import javassist.util.proxy.ProxyFactory;
 
 /**
  * Calls the methods annotated with {@link Initializer} on frame
@@ -25,9 +31,40 @@ class JavaFrameInitializer implements FrameInitializer {
 
 	private JavaHandlerModule module;
 
-	JavaFrameInitializer(JavaHandlerModule module) {
-		this.module = module;
-	}
+    /**
+     * Caches lists of InitializerMethods for a given frame class.  See "doLoad" method below.
+     */
+    private LoadingCache<Class<?>, List<InitializerMethod>> initializerCache = CacheBuilder
+            .newBuilder().build(new CacheLoader<Class<?>, List<InitializerMethod>>() {
+                @Override
+                public List<InitializerMethod> load(final Class<?> frameClass) throws Exception {
+                    return doLoad(frameClass);
+                }
+            });
+
+
+    JavaFrameInitializer(JavaHandlerModule module) {
+        this.module = module;
+    }
+
+    /**
+     * Captures the work of calling an "@Initializer" annotated method.
+     */
+    private class InitializerMethod {
+        private final Class<?> h;
+        private final Method method;
+
+        private InitializerMethod(Class<?> h, Method method) {
+            this.h = h;
+            this.method = method;
+        }
+
+        void execute(Object framedElement, FramedGraph<?> framedGraph, Element element)
+                throws InvocationTargetException, IllegalAccessException {
+            Object handler = module.createHandler(framedElement, framedGraph, element, h, method);
+            method.invoke(handler);
+        }
+    }
 
 	@Override
 	public void initElement(Class<?> kind, FramedGraph<?> framedGraph, Element element) {
@@ -39,64 +76,76 @@ class JavaFrameInitializer implements FrameInitializer {
 			framedElement = framedGraph.frame((Edge) element, kind);
 		}
 
-		// We have to order this correctly. Dependencies should be initialised
-		// first so we first recursively collect an an array of classes to call
-		// and then reverse the array before putting them in a linked hash set.
-		// That way the classes discovered last will be called first.
-		List<Class<?>> classes = new ArrayList<Class<?>>();
-		depthFirstClassSearch(classes, kind);
+        try {
+            for (InitializerMethod method : initializerCache.get(kind)) {
+                try {
+                    method.execute(framedElement, framedGraph, element);
+                } catch (IllegalArgumentException e) {
+                    throw new JavaHandlerException("Problem calling Java handler", e);
+                } catch (IllegalAccessException e) {
+                    throw new JavaHandlerException("Problem calling Java handler", e);
+                } catch (InvocationTargetException e) {
+                    ExceptionUtils.sneakyThrow(e.getTargetException());
+                }
+            }
+        } catch (ExecutionException e) {
+            throw new JavaHandlerException("Problem calling Java handler", e);
+        }
 
-		Collections.reverse(classes);
-		LinkedHashSet<Class<?>> hierarcy = new LinkedHashSet<Class<?>>(classes);
+    }
 
-		
-		// Now we can call the methods
-		for (Class<?> h : hierarcy) {
-			try {
-				
-				
-				try {
-					Class<?> implKind = module.getHandlerClass(h);
-					for (Method method : implKind.getDeclaredMethods()) {
-						if (method.isAnnotationPresent(Initializer.class)) {
-							if (method.getParameterTypes().length != 0) {
-								throw new JavaHandlerException("Java handler initializer " + method + "cannot have parameters");
-							}
-							Object handler = module.createHandler(framedElement, framedGraph, element, h, method);
-							method.invoke(handler);
-						}
+    /**
+     * Finds all the relevant @Initializer methods for the given class.
+     */
+    private List<InitializerMethod> doLoad(Class<?> kind) {
+        // We have to order this correctly. Dependencies should be initialised
+        // first so we first recursively collect an an array of classes to call
+        // and then reverse the array before putting them in a linked hash set.
+        // That way the classes discovered last will be called first.
+        List<Class<?>> classes = new ArrayList<Class<?>>();
+        depthFirstClassSearch(classes, kind);
 
-					}
-				} catch (ClassNotFoundException e) {
-					// There was no impl class to check
-				}
-				
-				
-				
-			} catch (IllegalArgumentException e) {
-				throw new JavaHandlerException("Problem calling Java handler", e);
-			} catch (IllegalAccessException e) {
-				throw new JavaHandlerException("Problem calling Java handler", e);
-			} catch (InvocationTargetException e) {
-				ExceptionUtils.sneakyThrow(e.getTargetException());
-			}
-		}
+        Collections.reverse(classes);
+        LinkedHashSet<Class<?>> hierarchy = new LinkedHashSet<Class<?>>(classes);
+        List<InitializerMethod> methods = Lists.newArrayList();
 
-	}
+        // Now we can store InitializerMethod objects for each method call.
+        for (Class<?> h : hierarchy) {
+            try {
+                try {
+                    Class<?> implKind = module.getHandlerClass(h);
+                    for (Method method : implKind.getDeclaredMethods()) {
+                        if (method.isAnnotationPresent(Initializer.class)) {
+                            if (method.getParameterTypes().length != 0) {
+                                throw new JavaHandlerException("Java handler initializer " + method + "cannot have parameters");
+                            }
+                            methods.add(new InitializerMethod(h, method));
+                        }
 
-	private void depthFirstClassSearch(List<Class<?>> initializers, Class<?> kind) {
+                    }
+                } catch (ClassNotFoundException e) {
+                    // There was no impl class to check
+                }
+            } catch (IllegalArgumentException e) {
+                throw new JavaHandlerException("Problem calling Java handler", e);
+            }
+        }
 
-		if (kind == null || kind == Object.class) {
-			return;
-		}
+        return methods;
+    }
 
-		initializers.add(kind);
+    private void depthFirstClassSearch(List<Class<?>> initializers, Class<?> kind) {
 
-		for (Class<?> i : kind.getInterfaces()) {
-			depthFirstClassSearch(initializers, i);
-		}
-		depthFirstClassSearch(initializers, kind.getSuperclass());
+        if (kind == null || kind == Object.class) {
+            return;
+        }
 
-	}
+        initializers.add(kind);
 
+        for (Class<?> i : kind.getInterfaces()) {
+            depthFirstClassSearch(initializers, i);
+        }
+        depthFirstClassSearch(initializers, kind.getSuperclass());
+
+    }
 }


### PR DESCRIPTION
The JavaHandlerModule.getHandlerClass uses getClassLoader().loadClass to find
the implementation for the given frameClass class to be used by the JavaHandler.
That loadClass call is quite slow.

In JavaHandlerModule I moved the call into the loading function of the LoadingCache.
That avoids making the call more than once.

The JavaFrameInitializer class also depends on getHandlerClass.  In this case there
was a lot of working happening to get all initializers a given frame class may
have inheritted and call them all in order.  I've created a LoadingCache so that
the work of getting all the methods together will only happen once.  This was slow
mostly because of the getHandlerClass call, but I decided to pull everything
I could into the cache.
