### PR TITLE
Added a pluggable type resolver classloader system

### DIFF
--- a/src/main/java/com/tinkerpop/frames/FramedGraph.java
+++ b/src/main/java/com/tinkerpop/frames/FramedGraph.java
@@ -103,7 +103,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 			resolvedTypes.addAll(Arrays.asList(typeResolver.resolveTypes(
 					vertex, kind)));
 		}
-		return (F) Proxy.newProxyInstance(kind.getClassLoader(),
+		return (F) Proxy.newProxyInstance(config.getFrameClassLoaderResolver().resolveClassLoader(kind),
 				resolvedTypes.toArray(new Class[resolvedTypes.size()]),
 				new FramedElement(this, vertex));
 	}
@@ -139,7 +139,7 @@ public class FramedGraph<T extends Graph> implements Graph, WrapperGraph<T> {
 			resolvedTypes.addAll(Arrays.asList(typeResolver.resolveTypes(edge,
 					kind)));
 		}
-		return (F) Proxy.newProxyInstance(kind.getClassLoader(),
+		return (F) Proxy.newProxyInstance(config.getFrameClassLoaderResolver().resolveClassLoader(kind),
 				resolvedTypes.toArray(new Class[resolvedTypes.size()]),
 				new FramedElement(this, edge, direction));
 	}

--- a/src/main/java/com/tinkerpop/frames/FramedGraphConfiguration.java
+++ b/src/main/java/com/tinkerpop/frames/FramedGraphConfiguration.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.frames.annotations.AnnotationHandler;
+import com.tinkerpop.frames.modules.DefaultClassLoaderResolver;
+import com.tinkerpop.frames.modules.FrameClassLoaderResolver;
 import com.tinkerpop.frames.modules.MethodHandler;
 import com.tinkerpop.frames.modules.Module;
 import com.tinkerpop.frames.modules.TypeResolver;
@@ -28,6 +30,7 @@ public class FramedGraphConfiguration {
 	private Map<Class<? extends Annotation>, MethodHandler<?>> methodHandlers = new HashMap<Class<? extends Annotation>, MethodHandler<?>>();
 	private List<FrameInitializer> frameInitializers = new ArrayList<FrameInitializer>();
 	private List<TypeResolver> typeResolvers = new ArrayList<TypeResolver>();
+	private FrameClassLoaderResolver frameClassLoaderResolver = new DefaultClassLoaderResolver();
 	private Graph configuredGraph;
 
 	
@@ -68,6 +71,10 @@ public class FramedGraphConfiguration {
 		typeResolvers.add(typeResolver);
 	}
 
+	public void setFrameClassLoaderResolver(FrameClassLoaderResolver frameClassLoaderResolver) {
+		this.frameClassLoaderResolver = frameClassLoaderResolver;    
+	}
+        
 	List<FrameInitializer> getFrameInitializers() {
 		return frameInitializers;
 	}
@@ -79,7 +86,11 @@ public class FramedGraphConfiguration {
 	List<TypeResolver> getTypeResolvers() {
 		return typeResolvers;
 	}
-	
+
+	FrameClassLoaderResolver getFrameClassLoaderResolver() {
+		return frameClassLoaderResolver;
+	}
+
 	public void setConfiguredGraph(Graph configuredGraph) {
 		this.configuredGraph = configuredGraph;
 	}

--- a/src/main/java/com/tinkerpop/frames/modules/DefaultClassLoaderResolver.java
+++ b/src/main/java/com/tinkerpop/frames/modules/DefaultClassLoaderResolver.java
@@ -1,0 +1,14 @@
+package com.tinkerpop.frames.modules;
+
+/**
+ * Implements a basic FrameClassLoaderResolver that simply returns
+ * the ClassLoader of the provided Frame Type.
+ *
+ * @author Jess Sightler <jesse.sightler@gmail.com>
+ */
+public class DefaultClassLoaderResolver implements FrameClassLoaderResolver {
+    @Override
+    public ClassLoader resolveClassLoader(Class<?> frameType) {
+        return frameType.getClassLoader();
+    }
+}

--- a/src/main/java/com/tinkerpop/frames/modules/FrameClassLoaderResolver.java
+++ b/src/main/java/com/tinkerpop/frames/modules/FrameClassLoaderResolver.java
@@ -1,0 +1,18 @@
+package com.tinkerpop.frames.modules;
+
+/**
+ * This allows the user to provide a custom ClassLoaderResolver. In some
+ * cases, the user may wish for a type to be framed with a non-default
+ * classloader (for example, if supplementary types from a TypeResolver
+ * need to be loaded from some other classloader).
+ * 
+ * This resolution system allows the user to provide their own custom classloader
+ * resolver.
+ *
+ * Instances of this class should be threadsafe.
+ * 
+ * @author Jess Sightler <jesse.sightler@gmail.com>
+ */
+public interface FrameClassLoaderResolver {
+    public ClassLoader resolveClassLoader(Class<?> frameType);
+}


### PR DESCRIPTION
This makes it possible to use a different classloader from the one that loaded the type being passed in. This is necessary in our case, as we have an attached TypeResolver that may add additional types that actually come from different classloaders.

A classloader resolver allows us to provide our own composite classloader that is able to pull in all of the required types.

The default behavior has been kept the same.
